### PR TITLE
fix fschat docker and workflow

### DIFF
--- a/.github/workflows/fastchat-deploy.yml
+++ b/.github/workflows/fastchat-deploy.yml
@@ -11,16 +11,13 @@ jobs:
   run_tests:
     runs-on: ascend-910b
     container:
-      image: zhangsibo1129/ubuntu-cann-torch21-py39:latest
+      image: zhangsibo1129/ubuntu-cann-torch21-py39-fschat:latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
         - /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64
         - /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info
         - /data/disk3/action/models/hub/:/opt/big_models/
-        - /data/disk3/action/envs/fschat/torch_npu:/root/miniconda/envs/torch_npu
-        - /data/disk3/action/repo:/__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
-        - /data/disk3/action/projects/FastChat:/__w/llm-tool-ci/llm-tool-ci/FastChat
       options: --network host
                --device /dev/davinci_manager
                --device /dev/devmm_svm
@@ -29,12 +26,12 @@ jobs:
                --device /dev/davinci7
     steps:
         - name: Copy_Test_Cases
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci
+          working-directory: /root/llm-tool-ci
           run: |
-            cp fastchat_test/cases/deploy/* /__w/llm-tool-ci/llm-tool-ci/FastChat/tests/
+            cp fastchat_test/cases/deploy/* /root/FastChat/tests/
 
         - name: run_deploy_cases
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/FastChat
+          working-directory: /root/FastChat
           run: |
             cp tests/*.txt .
             nohup python tests/launch_openai_api_test_server.py > local_api.log 2>&1 &

--- a/.github/workflows/fastchat-finetune.yml
+++ b/.github/workflows/fastchat-finetune.yml
@@ -12,7 +12,7 @@ jobs:
   run_tests:
     runs-on: ascend-910b
     container:
-      image: zhangsibo1129/ubuntu-cann-torch21-py39:latest
+      image: zhangsibo1129/ubuntu-cann-torch21-py39-fschat:latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
@@ -20,9 +20,6 @@ jobs:
         - /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info
         - /data/disk3/action/models/hub/:/opt/big_models/
         - /data/disk3/action/nlp_data/:/opt/nlp_data/
-        - /data/disk3/action/envs/fschat/torch_npu:/root/miniconda/envs/torch_npu
-        - /data/disk3/action/repo:/__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
-        - /data/disk3/action/projects/FastChat:/__w/llm-tool-ci/llm-tool-ci/FastChat
       options: --network host
                --device /dev/davinci_manager
                --device /dev/devmm_svm
@@ -31,13 +28,13 @@ jobs:
                --device /dev/davinci7
     steps:
         - name: Copy_Test_Cases
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci
+          working-directory: /root/llm-tool-ci
           run: |
-            cp fastchat_test/cases/fine_tune/* /__w/llm-tool-ci/llm-tool-ci/FastChat/tests/
+            cp fastchat_test/cases/fine_tune/* /root/FastChat/tests/
 
         - name: run_fine_tune_cases
           timeout-minutes: 60
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/FastChat
+          working-directory: /root/FastChat
           run: |
             python tests/test_fine_tune.py > fine_tune.log
             sleep 1000

--- a/.github/workflows/fastchat-inference.yml
+++ b/.github/workflows/fastchat-inference.yml
@@ -3,7 +3,7 @@ run-name: FastChat NPU Inference
 
 on:
    schedule:
-     - cron: '0 30 1 * *'
+     - cron: '30 1 * * *'
 
 jobs:
   check_runner:
@@ -19,7 +19,7 @@ jobs:
       matrix:
         machine_type: [single-npu, multi-npu]
     container: 
-      image: zhangsibo1129/ubuntu-cann-torch21-py39:latest
+      image: zhangsibo1129/ubuntu-cann-torch21-py39-fschat:latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
@@ -49,68 +49,38 @@ jobs:
     runs-on: ascend-910b
     needs: check_npu_environment
     container: 
-      image: zhangsibo1129/ubuntu-cann-torch21-py39:latest
+      image: zhangsibo1129/ubuntu-cann-torch21-py39-fschat:latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
         - /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64
         - /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info
         - /data/disk3/action/models/hub:/opt/big_models/
-        - /data/disk3/action/envs/fschat:/root/data
-        - /data/disk3/action/repo:/__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
-        - /data/disk3/action/projects/FastChat:/__w/llm-tool-ci/llm-tool-ci/FastChat
-
       options: --network host
                --device /dev/davinci_manager
                --device /dev/devmm_svm
                --device /dev/hisi_hdc
                --device /dev/davinci6
     steps:
-        - name: Get FastChat Latest Code
-          uses: actions/checkout@v4
-          with:
-            repository: lm-sys/FastChat
-            ssh-key: ${{ secrets.SECRET_SSH_KEY }}
-            path: FastChat
-            clean: true
-        - name: Pull FastChat
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/FastChat
-          run: |
-            git pull
-            pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple
-            pip3 install -e ".[model_worker,webui]" -i https://pypi.tuna.tsinghua.edu.cn/simple
-            pip install SentencePiece xformers -i https://pypi.tuna.tsinghua.edu.cn/simple
-        - name: Get CI Code
-          uses: actions/checkout@v4
-          with:
-            ssh-key: ${{ secrets.SECRET_SSH_KEY }}
-            path: llm-tool-ci
         - name: Import Verification
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/FastChat
+          working-directory: /root/FastChat
           run: |
             python << EOF
             if __name__ == '__main__':
                 from fastchat.conversation import SeparatorStyle
                 from fastchat.model.model_adapter import get_conversation_template
             EOF
-        - name: Persistent Python Interpreter
-          run: |
-            rm -rf /root/data/torch_npu
-            mv /root/miniconda/envs/torch_npu /root/data
   run_tests:
     runs-on: ascend-910b
     needs: install_fastchat
     container:
-      image: zhangsibo1129/ubuntu-cann-torch21-py39:latest
+      image: zhangsibo1129/ubuntu-cann-torch21-py39-fschat:latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
         - /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64
         - /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info
         - /data/disk3/action/models/hub/:/opt/big_models/
-        - /data/disk3/action/envs/fschat/torch_npu:/root/miniconda/envs/torch_npu
-        - /data/disk3/action/repo:/__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
-        - /data/disk3/action/projects/FastChat:/__w/llm-tool-ci/llm-tool-ci/FastChat
       options: --network host
                --device /dev/davinci_manager
                --device /dev/devmm_svm
@@ -119,12 +89,12 @@ jobs:
                --device /dev/davinci7
     steps:
         - name: Copy_Test_Cases
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci
+          working-directory: /root/llm-tool-ci
           run: |
-            cp fastchat_test/cases/inference/* /__w/llm-tool-ci/llm-tool-ci/FastChat/tests/
+            cp fastchat_test/cases/inference/* /root/FastChat/tests/
 
         - name: run_inference_cases
-          working-directory: /__w/llm-tool-ci/llm-tool-ci/FastChat
+          working-directory: /root/FastChat
           run: |
             cp tests/*.txt .
             python tests/test_cli.py

--- a/.github/workflows/fastchat-scan-models.yml
+++ b/.github/workflows/fastchat-scan-models.yml
@@ -12,7 +12,7 @@ jobs:
   scan_models:
     runs-on: ascend-910b
     container:
-      image: zhangsibo1129/ubuntu-cann-torch21-py39:latest
+      image: zhangsibo1129/ubuntu-cann-torch21-py39-fschat:latest
       volumes:
         - /usr/local/dcmi:/usr/local/dcmi
         - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
@@ -20,9 +20,6 @@ jobs:
         - /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info
         - /data/disk3/action/models/hub/:/opt/big_models/
         - /data/disk3/action/nlp_data/:/opt/nlp_data/
-        - /data/disk3/action/envs/fschat/torch_npu:/root/miniconda/envs/torch_npu
-        - /data/disk3/action/repo:/__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
-        - /data/disk3/action/projects/FastChat:/__w/llm-tool-ci/llm-tool-ci/FastChat
       options: --network host
         --device /dev/davinci_manager
         --device /dev/devmm_svm
@@ -30,42 +27,25 @@ jobs:
         --device /dev/davinci6
         --device /dev/davinci7
     steps:
-
-      - name: Preprocess
-        working-directory: /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci
-        run: |
-          cp fastchat_test/cases/scan_models/* /__w/llm-tool-ci/llm-tool-ci/FastChat/tests/
-          cp fastchat_test/fastchat-model-test-map.json /__w/llm-tool-ci/llm-tool-ci/FastChat/
-      - name: Run Scan Models
-        timeout-minutes: 120
-        working-directory: /__w/llm-tool-ci/llm-tool-ci/FastChat
-        run: |
-          python tests/test_scan_models.py fastchat-model-test-map.json
-          echo 'scan models done.'
-          cp fastchat-models.json /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
-          echo 'fastchat-models.json copy done.'
-  update_readme:
-    runs-on: ascend-910b
-    needs: scan_models
-    container:
-      image: zhangsibo1129/ubuntu-cann-torch21-py39:latest
-      volumes:
-        - /usr/local/dcmi:/usr/local/dcmi
-        - /usr/local/bin/npu-smi:/usr/local/bin/npu-smi
-        - /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64
-        - /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info
-        - /data/disk3/action/envs/fschat/torch_npu:/root/miniconda/envs/torch_npu
-        - /data/disk3/action/repo:/__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
-      options: --network host
-        --device /dev/davinci_manager
-
-    steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.SECRET_SSH_KEY }}
           path: llm-tool-ci
           clean: false
+      - name: Preprocess
+        working-directory: /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci
+        run: |
+          cp fastchat_test/cases/scan_models/* /root/FastChat/tests/
+          cp fastchat_test/fastchat-model-test-map.json /root/FastChat/
+      - name: Run Scan Models
+        timeout-minutes: 120
+        working-directory: /root/FastChat
+        run: |
+          python tests/test_scan_models.py fastchat-model-test-map.json
+          echo 'scan models done.'
+          cp fastchat-models.json /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci/
+          echo 'fastchat-models.json copy done.'
       - name: Write Table to README
         working-directory: /__w/llm-tool-ci/llm-tool-ci/llm-tool-ci
         run: |

--- a/docker/fschat/Dockerfile
+++ b/docker/fschat/Dockerfile
@@ -8,6 +8,8 @@ RUN apt update && \
     libsndfile1 && \
     rm -rf /var/lib/apt/lists/*
 
+RUN git clone https://github.com/npu-ci/llm-tool-ci.git
+
 RUN git clone https://github.com/lm-sys/FastChat.git && \
     cd FastChat && \
     git checkout $REF
@@ -16,3 +18,4 @@ ENV PIP_SOURCE_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 
 RUN cd FastChat && \
     pip install --no-cache-dir -e ".[model_worker,webui]" -i ${PIP_SOURCE_URL}
+    pip install SentencePiece -i ${PIP_SOURCE_URL}

--- a/docker/fschat/Dockerfile
+++ b/docker/fschat/Dockerfile
@@ -17,5 +17,4 @@ RUN git clone https://github.com/lm-sys/FastChat.git && \
 ENV PIP_SOURCE_URL=https://pypi.tuna.tsinghua.edu.cn/simple
 
 RUN cd FastChat && \
-    pip install --no-cache-dir -e ".[model_worker,webui]" -i ${PIP_SOURCE_URL}
-    pip install SentencePiece -i ${PIP_SOURCE_URL}
+    pip install --no-cache-dir -e ".[model_worker]" -i ${PIP_SOURCE_URL}


### PR DESCRIPTION
修改fschat工作流，适配dockerfile
SentencePiece 必须安装：
Traceback (most recent call last):
  File "/opt/nlp_data/FastChat/fastchat/train/train.py", line 317, in <module>
    train()
  File "/opt/nlp_data/FastChat/fastchat/train/train.py", line 283, in train
    tokenizer = transformers.AutoTokenizer.from_pretrained(
  File "/root/miniconda/envs/torch_npu/lib/python3.9/site-packages/transformers/models/auto/tokenization_auto.py", line 768, in from_pretrained
    return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)
  File "/root/miniconda/envs/torch_npu/lib/python3.9/site-packages/transformers/utils/import_utils.py", line 1259, in __getattribute__
    requires_backends(cls, cls._backends)
  File "/root/miniconda/envs/torch_npu/lib/python3.9/site-packages/transformers/utils/import_utils.py", line 1247, in requires_backends
    raise ImportError("".join(failed))
ImportError: 
LlamaTokenizer requires the SentencePiece library but it was not found in your environment. Checkout the instructions on the
installation page of its repo: https://github.com/google/sentencepiece#installation and follow the ones
that match your environment. Please note that you may need to restart your runtime after installation.